### PR TITLE
Allow priorities to be Floats

### DIFF
--- a/src/SimJulia.jl
+++ b/src/SimJulia.jl
@@ -3,31 +3,32 @@ Main module for SimJulia.jl – a discrete event process oriented simulation fra
 """
 module SimJulia
 
-  using DataStructures
-  using Dates
-  using ResumableFunctions
+using DataStructures
+using Dates
+using ResumableFunctions
 
-  import Base.run, Base.isless, Base.show, Base.yield, Base.get
-  import Base.(&), Base.(|)
-  import Dates.now
+import Base.run, Base.isless, Base.show, Base.yield, Base.get
+import Base.(&), Base.(|)
+import Dates.now
 
-  export AbstractEvent, Environment, value, state, environment
-  export Event, succeed, fail, @callback, remove_callback
-  export timeout
-  export Operator, (&), (|), AllOf, AnyOf
-  export @resumable, @yield
-  export AbstractProcess, Simulation, run, now, active_process, StopSimulation
-  export Process, @process, interrupt
-  export Container, Resource, Store, put, get, request, release, cancel
-  export nowDatetime
+export AbstractEvent, Environment, value, state, environment
+export Event, succeed, fail, @callback, remove_callback
+export timeout
+export Operator, (&), (|), AllOf, AnyOf
+export @resumable, @yield
+export AbstractProcess, Simulation, run, now, active_process, StopSimulation
+export Process, @process, interrupt
+export Container, Resource, Store, put, get, request, release, cancel
+export nowDatetime
 
-  include("base.jl")
-  include("events.jl")
-  include("operators.jl")
-  include("simulations.jl")
-  include("processes.jl")
-  include("resources/base.jl")
-  include("resources/containers.jl")
-  include("resources/stores.jl")
-  include("utils/time.jl")
+include("base.jl")
+include("events.jl")
+include("operators.jl")
+include("simulations.jl")
+include("processes.jl")
+include("resources/base.jl")
+include("resources/containers.jl")
+include("resources/stores.jl")
+include("utils/time.jl")
+
 end

--- a/src/base.jl
+++ b/src/base.jl
@@ -41,10 +41,12 @@ end
 function value(ev::AbstractEvent)::Any
     ev.bev.value
 end
+value(ev::Nothing) = nothing
 
 function state(ev::AbstractEvent)::EVENT_STATE
     ev.bev.state
 end
+state(ev::Nothing) = processed
 
 function append_callback(func::Function, ev::AbstractEvent, args::Any...)::Function
     ev.bev.state === processed && throw(EventProcessed(ev))

--- a/src/base.jl
+++ b/src/base.jl
@@ -1,100 +1,100 @@
 abstract type AbstractEvent end
 abstract type Environment end
 
-@enum EVENT_STATE idle=0 scheduled=1 processed=2
+@enum EVENT_STATE idle = 0 scheduled = 1 processed = 2
 
 struct EventProcessed <: Exception
-  ev :: AbstractEvent
+    ev::AbstractEvent
 end
 
 struct EventNotIdle <: Exception
-  ev :: AbstractEvent
+    ev::AbstractEvent
 end
 
 mutable struct BaseEvent
-  env :: Environment
-  id :: UInt
-  callbacks :: Vector{Function}
-  state :: EVENT_STATE
-  value :: Any
-  function BaseEvent(env::Environment)
-    new(env, env.eid+=one(UInt), Vector{Function}(), idle, nothing)
-  end
+    env::Environment
+    id::UInt
+    callbacks::Vector{Function}
+    state::EVENT_STATE
+    value::Any
+    function BaseEvent(env::Environment)
+        new(env, env.eid += one(UInt), Vector{Function}(), idle, nothing)
+    end
 end
 
 function show(io::IO, ev::AbstractEvent)
-  print(io, "$(typeof(ev)) $(ev.bev.id)")
+    print(io, "$(typeof(ev)) $(ev.bev.id)")
 end
 
 function show(io::IO, env::Environment)
-  if env.active_proc === nothing
-    print(io, "$(typeof(env)) time: $(now(env)) active_process: nothing")
-  else
-    print(io, "$(typeof(env)) time: $(now(env)) active_process: $(env.active_proc)")
-  end
+    if env.active_proc === nothing
+        print(io, "$(typeof(env)) time: $(now(env)) active_process: nothing")
+    else
+        print(io, "$(typeof(env)) time: $(now(env)) active_process: $(env.active_proc)")
+    end
 end
 
-function environment(ev::AbstractEvent) :: Environment
-  ev.bev.env
+function environment(ev::AbstractEvent)::Environment
+    ev.bev.env
 end
 
-function value(ev::AbstractEvent) :: Any
-  ev.bev.value
+function value(ev::AbstractEvent)::Any
+    ev.bev.value
 end
 
-function state(ev::AbstractEvent) :: EVENT_STATE
-  ev.bev.state
+function state(ev::AbstractEvent)::EVENT_STATE
+    ev.bev.state
 end
 
-function append_callback(func::Function, ev::AbstractEvent, args::Any...) :: Function
-  ev.bev.state === processed && throw(EventProcessed(ev))
-  cb = ()->func(ev, args...)
-  push!(ev.bev.callbacks, cb)
-  cb
+function append_callback(func::Function, ev::AbstractEvent, args::Any...)::Function
+    ev.bev.state === processed && throw(EventProcessed(ev))
+    cb = () -> func(ev, args...)
+    push!(ev.bev.callbacks, cb)
+    cb
 end
 
 macro callback(expr::Expr)
-  expr.head !== :call && error("Expression is not a function call!")
-  esc(:(SimJulia.append_callback($(expr.args...))))
+    expr.head !== :call && error("Expression is not a function call!")
+    esc(:(SimJulia.append_callback($(expr.args...))))
 end
 
 function remove_callback(cb::Function, ev::AbstractEvent)
-  i = findfirst(x -> x == cb, ev.bev.callbacks)
-  i != 0 && deleteat!(ev.bev.callbacks, i)
+    i = findfirst(x -> x == cb, ev.bev.callbacks)
+    i != 0 && deleteat!(ev.bev.callbacks, i)
 end
 
 function schedule(ev::AbstractEvent, delay::Number=zero(Float64); priority::Int=0, value::Any=nothing)
-  state(ev) === processed && throw(EventProcessed(ev))
-  env = environment(ev)
-  bev = ev.bev
-  bev.value = value
-  env.heap[bev] = EventKey(now(env) + delay, priority, env.sid+=one(UInt))
-  bev.state = scheduled
-  ev
+    state(ev) === processed && throw(EventProcessed(ev))
+    env = environment(ev)
+    bev = ev.bev
+    bev.value = value
+    env.heap[bev] = EventKey(now(env) + delay, priority, env.sid += one(UInt))
+    bev.state = scheduled
+    ev
 end
 
 struct StopSimulation <: Exception
-  value :: Any
-  function StopSimulation(value::Any=nothing)
-    new(value)
-  end
+    value::Any
+    function StopSimulation(value::Any=nothing)
+        new(value)
+    end
 end
 
 function stop_simulation(ev::AbstractEvent)
-  throw(StopSimulation(value(ev)))
+    throw(StopSimulation(value(ev)))
 end
 
 function run(env::Environment, until::AbstractEvent)
-  @callback stop_simulation(until)
-  try
-    while true
-      step(env)
+    @callback stop_simulation(until)
+    try
+        while true
+            step(env)
+        end
+    catch exc
+        if isa(exc, StopSimulation)
+            return exc.value
+        else
+            rethrow(exc)
+        end
     end
-  catch exc
-    if isa(exc, StopSimulation)
-      return exc.value
-    else
-      rethrow(exc)
-    end
-  end
 end

--- a/src/base.jl
+++ b/src/base.jl
@@ -65,7 +65,7 @@ function remove_callback(cb::Function, ev::AbstractEvent)
     i != 0 && deleteat!(ev.bev.callbacks, i)
 end
 
-function schedule(ev::AbstractEvent, delay::Number=zero(Float64); priority::Int=0, value::Any=nothing)
+function schedule(ev::AbstractEvent, delay::Number=zero(Float64); priority::Real=0, value::Any=nothing)
     state(ev) === processed && throw(EventProcessed(ev))
     env = environment(ev)
     bev = ev.bev

--- a/src/events.jl
+++ b/src/events.jl
@@ -5,12 +5,12 @@ struct Event <: AbstractEvent
     end
 end
 
-function succeed(ev::Event; priority::Int=0, value::Any=nothing)::Event
+function succeed(ev::Event; priority::Real=0, value::Any=nothing)::Event
     state(ev) !== idle && throw(EventNotIdle(ev))
     schedule(ev; priority=priority, value=value)
 end
 
-function fail(ev::Event, exc::Exception; priority::Int=0)::Event
+function fail(ev::Event, exc::Exception; priority::Real=0)::Event
     succeed(ev; priority=priority, value=exc)
 end
 
@@ -21,7 +21,7 @@ struct Timeout <: AbstractEvent
     end
 end
 
-function timeout(env::Environment, delay::Number=0; priority::Int=0, value::Any=nothing)
+function timeout(env::Environment, delay::Number=0; priority::Real=0, value::Any=nothing)
     schedule(Timeout(env), delay; priority=priority, value=value)
 end
 

--- a/src/events.jl
+++ b/src/events.jl
@@ -1,30 +1,30 @@
 struct Event <: AbstractEvent
-  bev :: BaseEvent
-  function Event(env::Environment)
-    new(BaseEvent(env))
-  end
+    bev::BaseEvent
+    function Event(env::Environment)
+        new(BaseEvent(env))
+    end
 end
 
-function succeed(ev::Event; priority::Int=0, value::Any=nothing) :: Event
-  state(ev) !== idle && throw(EventNotIdle(ev))
-  schedule(ev; priority=priority, value=value)
+function succeed(ev::Event; priority::Int=0, value::Any=nothing)::Event
+    state(ev) !== idle && throw(EventNotIdle(ev))
+    schedule(ev; priority=priority, value=value)
 end
 
-function fail(ev::Event, exc::Exception; priority::Int=0) :: Event
-  succeed(ev; priority=priority, value=exc)
+function fail(ev::Event, exc::Exception; priority::Int=0)::Event
+    succeed(ev; priority=priority, value=exc)
 end
 
 struct Timeout <: AbstractEvent
-  bev :: BaseEvent
-  function Timeout(env::Environment)
-    new(BaseEvent(env))
-  end
+    bev::BaseEvent
+    function Timeout(env::Environment)
+        new(BaseEvent(env))
+    end
 end
 
 function timeout(env::Environment, delay::Number=0; priority::Int=0, value::Any=nothing)
-  schedule(Timeout(env), delay; priority=priority, value=value)
+    schedule(Timeout(env), delay; priority=priority, value=value)
 end
 
 function run(env::Environment, until::Number=typemax(Float64))
-  run(env, timeout(env, until-now(env)))
+    run(env, timeout(env, until - now(env)))
 end

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -1,64 +1,64 @@
 struct StateValue
-  state :: EVENT_STATE
-  value :: Any
-  function StateValue(state::EVENT_STATE, value::Any=nothing)
-    new(state, value)
-  end
+    state::EVENT_STATE
+    value::Any
+    function StateValue(state::EVENT_STATE, value::Any=nothing)
+        new(state, value)
+    end
 end
 
 struct Operator <: AbstractEvent
-  bev :: BaseEvent
-  eval :: Function
-  function Operator(eval::Function, fev::AbstractEvent, events::AbstractEvent...)
-    env = environment(fev)
-    op = new(BaseEvent(env), eval)
-    event_state_values = Dict{AbstractEvent, StateValue}()
-    for ev in tuple(fev, events...)
-      event_state_values[ev] = StateValue(state(ev))
-      @callback check(ev, op, event_state_values)
+    bev::BaseEvent
+    eval::Function
+    function Operator(eval::Function, fev::AbstractEvent, events::AbstractEvent...)
+        env = environment(fev)
+        op = new(BaseEvent(env), eval)
+        event_state_values = Dict{AbstractEvent,StateValue}()
+        for ev in tuple(fev, events...)
+            event_state_values[ev] = StateValue(state(ev))
+            @callback check(ev, op, event_state_values)
+        end
+        op
     end
-    op
-  end
 end
 
-function check(ev::AbstractEvent, op::Operator, event_state_values::Dict{AbstractEvent, StateValue})
-  val = value(ev)
-  if state(op) === idle
-    if isa(val, Exception)
-      schedule(op; value=val)
-    else
-      event_state_values[ev] = StateValue(state(ev), val)
-      op.eval(collect(values(event_state_values))) && schedule(op; value=event_state_values)
+function check(ev::AbstractEvent, op::Operator, event_state_values::Dict{AbstractEvent,StateValue})
+    val = value(ev)
+    if state(op) === idle
+        if isa(val, Exception)
+            schedule(op; value=val)
+        else
+            event_state_values[ev] = StateValue(state(ev), val)
+            op.eval(collect(values(event_state_values))) && schedule(op; value=event_state_values)
+        end
+    elseif state(op) === scheduled
+        if isa(val, Exception)
+            schedule(op; priority=typemax(Int), value=val)
+        else
+            event_state_values[ev] = StateValue(state(ev), val)
+        end
     end
-  elseif state(op) === scheduled
-    if isa(val, Exception)
-      schedule(op; priority=typemax(Int), value=val)
-    else
-      event_state_values[ev] = StateValue(state(ev), val)
-    end
-  end
 end
 
 function eval_and(state_values::Vector{StateValue})
-  all(map((sv)->sv.state === processed, state_values))
+    all(map((sv) -> sv.state === processed, state_values))
 end
 
 function eval_or(state_values::Vector{StateValue})
-  any(map((sv)->sv.state === processed, state_values))
+    any(map((sv) -> sv.state === processed, state_values))
 end
 
 function (&)(ev1::AbstractEvent, ev2::AbstractEvent)
-  Operator(eval_and, ev1, ev2)
+    Operator(eval_and, ev1, ev2)
 end
 
 function (|)(ev1::AbstractEvent, ev2::AbstractEvent)
-  Operator(eval_or, ev1, ev2)
+    Operator(eval_or, ev1, ev2)
 end
 
 function AllOf(events...)
-  Operator(eval_and,events...)
+    Operator(eval_and, events...)
 end
 
 function AnyOf(events...)
-  Operator(eval_or,events...)
+    Operator(eval_or, events...)
 end

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -58,7 +58,9 @@ end
 function AllOf(events...)
     Operator(eval_and, events...)
 end
+AllOf() = nothing
 
 function AnyOf(events...)
     Operator(eval_or, events...)
 end
+AnyOf() = nothing

--- a/src/processes.jl
+++ b/src/processes.jl
@@ -1,65 +1,65 @@
 struct Initialize <: AbstractEvent
-  bev :: BaseEvent
-  function Initialize(env::Environment)
-    new(BaseEvent(env))
-  end
+    bev::BaseEvent
+    function Initialize(env::Environment)
+        new(BaseEvent(env))
+    end
 end
 
 mutable struct Process <: DiscreteProcess
-  bev :: BaseEvent
-  fsmi :: ResumableFunctions.FiniteStateMachineIterator
-  target :: AbstractEvent
-  resume :: Function
-  function Process(func::Function, env::Environment, args...; kwargs...)
-    proc = new()
-    proc.bev = BaseEvent(env)
-    proc.fsmi = func(env, args...; kwargs...)
-    proc.target = schedule(Initialize(env))
-    proc.resume = @callback execute(proc.target, proc)
-    proc
-  end
+    bev::BaseEvent
+    fsmi::ResumableFunctions.FiniteStateMachineIterator
+    target::AbstractEvent
+    resume::Function
+    function Process(func::Function, env::Environment, args...; kwargs...)
+        proc = new()
+        proc.bev = BaseEvent(env)
+        proc.fsmi = func(env, args...; kwargs...)
+        proc.target = schedule(Initialize(env))
+        proc.resume = @callback execute(proc.target, proc)
+        proc
+    end
 end
 
 macro process(expr)
-  expr.head !== :call && error("Expression is not a function call!")
-  esc(:(Process($(expr.args...))))
+    expr.head !== :call && error("Expression is not a function call!")
+    esc(:(Process($(expr.args...))))
 end
 
 function execute(ev::AbstractEvent, proc::Process)
-  try
-    env = environment(ev)
-    set_active_process(env, proc)
-    target = proc.fsmi(value(ev))
-    reset_active_process(env)
-    if proc.fsmi._state === 0xff
-      schedule(proc; value=target)
-    else
-      proc.target = state(target) == processed ? timeout(env; value=value(target)) : target
-      proc.resume = @callback execute(proc.target, proc)
+    try
+        env = environment(ev)
+        set_active_process(env, proc)
+        target = proc.fsmi(value(ev))
+        reset_active_process(env)
+        if proc.fsmi._state === 0xff
+            schedule(proc; value=target)
+        else
+            proc.target = state(target) == processed ? timeout(env; value=value(target)) : target
+            proc.resume = @callback execute(proc.target, proc)
+        end
+    catch exc
+        rethrow(exc)
     end
-  catch exc
-    rethrow(exc)
-  end
 end
 
 struct Interrupt <: AbstractEvent
-  bev :: BaseEvent
-  function Interrupt(env::Environment)
-    new(BaseEvent(env))
-  end
+    bev::BaseEvent
+    function Interrupt(env::Environment)
+        new(BaseEvent(env))
+    end
 end
 
 function execute_interrupt(ev::Interrupt, proc::Process)
-  remove_callback(proc.resume, proc.target)
-  execute(ev, proc)
+    remove_callback(proc.resume, proc.target)
+    execute(ev, proc)
 end
 
 function interrupt(proc::Process, cause::Any=nothing)
-  env = environment(proc)
-  if proc.fsmi._state !== 0xff
-    proc.target isa Initialize && schedule(proc.target; priority=typemax(Int))
-    target = schedule(Interrupt(env); priority=typemax(Int), value=InterruptException(active_process(env), cause))
-    @callback execute_interrupt(target, proc)
-  end
-  timeout(env; priority=typemax(Int))
+    env = environment(proc)
+    if proc.fsmi._state !== 0xff
+        proc.target isa Initialize && schedule(proc.target; priority=typemax(Int))
+        target = schedule(Interrupt(env); priority=typemax(Int), value=InterruptException(active_process(env), cause))
+        @callback execute_interrupt(target, proc)
+    end
+    timeout(env; priority=typemax(Int))
 end

--- a/src/resources/base.jl
+++ b/src/resources/base.jl
@@ -3,53 +3,53 @@ abstract type ResourceKey end
 abstract type AbstractResource end
 
 function show(io::IO, res::AbstractResource)
-  print(io, "$(typeof(res))")
+    print(io, "$(typeof(res))")
 end
 
 abstract type ResourceEvent <: AbstractEvent end
 
 struct Put <: ResourceEvent
-  bev :: BaseEvent
-  function Put(env::Environment)
-    new(BaseEvent(env))
-  end
+    bev::BaseEvent
+    function Put(env::Environment)
+        new(BaseEvent(env))
+    end
 end
 
 struct Get <: ResourceEvent
-  bev :: BaseEvent
-  function Get(env::Environment)
-    new(BaseEvent(env))
-  end
+    bev::BaseEvent
+    function Get(env::Environment)
+        new(BaseEvent(env))
+    end
 end
 
 function isless(a::ResourceKey, b::ResourceKey)
-  (a.priority < b.priority) || (a.priority === b.priority && a.id < b.id)
+    (a.priority < b.priority) || (a.priority === b.priority && a.id < b.id)
 end
 
 function trigger_put(put_ev::ResourceEvent, res::AbstractResource)
-  queue = DataStructures.PriorityQueue(res.put_queue)
-  while length(queue) > 0
-    (put_ev, key) = DataStructures.peek(queue)
-    proceed = do_put(res, put_ev, key)
-    state(put_ev) === scheduled && DataStructures.dequeue!(res.put_queue, put_ev)
-    proceed ? DataStructures.dequeue!(queue) : break
-  end
+    queue = DataStructures.PriorityQueue(res.put_queue)
+    while length(queue) > 0
+        (put_ev, key) = DataStructures.peek(queue)
+        proceed = do_put(res, put_ev, key)
+        state(put_ev) === scheduled && DataStructures.dequeue!(res.put_queue, put_ev)
+        proceed ? DataStructures.dequeue!(queue) : break
+    end
 end
 
 function trigger_get(get_ev::ResourceEvent, res::AbstractResource)
-  queue = DataStructures.PriorityQueue(res.get_queue)
-  while length(queue) > 0
-    (get_ev, key) = DataStructures.peek(queue)
-    proceed = do_get(res, get_ev, key)
-    state(get_ev) === scheduled && DataStructures.dequeue!(res.get_queue, get_ev)
-    proceed ? DataStructures.dequeue!(queue) : break
-  end
+    queue = DataStructures.PriorityQueue(res.get_queue)
+    while length(queue) > 0
+        (get_ev, key) = DataStructures.peek(queue)
+        proceed = do_get(res, get_ev, key)
+        state(get_ev) === scheduled && DataStructures.dequeue!(res.get_queue, get_ev)
+        proceed ? DataStructures.dequeue!(queue) : break
+    end
 end
 
 function cancel(res::AbstractResource, put_ev::Put)
-  DataStructures.dequeue!(res.put_queue, put_ev)
+    DataStructures.dequeue!(res.put_queue, put_ev)
 end
 
 function cancel(res::AbstractResource, get_ev::Get)
-  DataStructures.dequeue!(res.get_queue, get_ev)
+    DataStructures.dequeue!(res.get_queue, get_ev)
 end

--- a/src/resources/containers.jl
+++ b/src/resources/containers.jl
@@ -1,57 +1,57 @@
 struct ContainerKey{N<:Real} <: ResourceKey
-  priority :: Real
-  id :: UInt
-  amount :: N
+    priority::Real
+    id::UInt
+    amount::N
 end
 
 mutable struct Container{N<:Real} <: AbstractResource
-  env :: Environment
-  capacity :: N
-  level :: N
-  seid :: UInt
-  put_queue :: DataStructures.PriorityQueue{Put, ContainerKey{N}}
-  get_queue :: DataStructures.PriorityQueue{Get, ContainerKey{N}}
-  function Container{N}(env::Environment, capacity::N=one(N); level::N=zero(N)) where {N<:Real}
-    new(env, capacity, level, zero(UInt), DataStructures.PriorityQueue{Put, ContainerKey{N}}(), DataStructures.PriorityQueue{Get, ContainerKey{N}}())
-  end
+    env::Environment
+    capacity::N
+    level::N
+    seid::UInt
+    put_queue::DataStructures.PriorityQueue{Put,ContainerKey{N}}
+    get_queue::DataStructures.PriorityQueue{Get,ContainerKey{N}}
+    function Container{N}(env::Environment, capacity::N=one(N); level::N=zero(N)) where {N<:Real}
+        new(env, capacity, level, zero(UInt), DataStructures.PriorityQueue{Put,ContainerKey{N}}(), DataStructures.PriorityQueue{Get,ContainerKey{N}}())
+    end
 end
 
-function Container(env::Environment, capacity::N=one(N); level::N=zero(N)) where N<:Real
-  Container{N}(env, capacity, level=level)
+function Container(env::Environment, capacity::N=one(N); level::N=zero(N)) where {N<:Real}
+    Container{N}(env, capacity, level=level)
 end
 
 const Resource = Container{Int}
 
-function put(con::Container{N}, amount::N; priority::Real=0) where N<:Real
-  put_ev = Put(con.env)
-  con.put_queue[put_ev] = ContainerKey(priority, con.seid+=one(UInt), amount)
-  @callback trigger_get(put_ev, con)
-  trigger_put(put_ev, con)
-  put_ev
+function put(con::Container{N}, amount::N; priority::Real=0) where {N<:Real}
+    put_ev = Put(con.env)
+    con.put_queue[put_ev] = ContainerKey(priority, con.seid += one(UInt), amount)
+    @callback trigger_get(put_ev, con)
+    trigger_put(put_ev, con)
+    put_ev
 end
 
 request(res::Resource; priority::Real=0) = put(res, 1; priority=priority)
 
-function get(con::Container{N}, amount::N; priority::Real=0) where N<:Real
-  get_ev = Get(con.env)
-  con.get_queue[get_ev] = ContainerKey(priority, con.seid+=one(UInt), amount)
-  @callback trigger_put(get_ev, con)
-  trigger_get(get_ev, con)
-  get_ev
+function get(con::Container{N}, amount::N; priority::Real=0) where {N<:Real}
+    get_ev = Get(con.env)
+    con.get_queue[get_ev] = ContainerKey(priority, con.seid += one(UInt), amount)
+    @callback trigger_put(get_ev, con)
+    trigger_get(get_ev, con)
+    get_ev
 end
 
 release(res::Resource; priority::Real=0) = get(res, 1; priority=priority)
 
-function do_put(con::Container{N}, put_ev::Put, key::ContainerKey{N}) where N<:Real
-  con.level + key.amount > con.capacity && return false
-  schedule(put_ev)
-  con.level += key.amount
-  true
+function do_put(con::Container{N}, put_ev::Put, key::ContainerKey{N}) where {N<:Real}
+    con.level + key.amount > con.capacity && return false
+    schedule(put_ev)
+    con.level += key.amount
+    true
 end
 
-function do_get(con::Container{N}, get_ev::Get, key::ContainerKey{N}) where N<:Real
-  con.level - key.amount < zero(N) && return false
-  schedule(get_ev)
-  con.level -= key.amount
-  true
+function do_get(con::Container{N}, get_ev::Get, key::ContainerKey{N}) where {N<:Real}
+    con.level - key.amount < zero(N) && return false
+    schedule(get_ev)
+    con.level -= key.amount
+    true
 end

--- a/src/resources/containers.jl
+++ b/src/resources/containers.jl
@@ -1,5 +1,5 @@
 struct ContainerKey{N<:Real} <: ResourceKey
-  priority :: Int
+  priority :: Real
   id :: UInt
   amount :: N
 end
@@ -22,7 +22,7 @@ end
 
 const Resource = Container{Int}
 
-function put(con::Container{N}, amount::N; priority::Int=0) where N<:Real
+function put(con::Container{N}, amount::N; priority::Real=0) where N<:Real
   put_ev = Put(con.env)
   con.put_queue[put_ev] = ContainerKey(priority, con.seid+=one(UInt), amount)
   @callback trigger_get(put_ev, con)
@@ -30,9 +30,9 @@ function put(con::Container{N}, amount::N; priority::Int=0) where N<:Real
   put_ev
 end
 
-request(res::Resource; priority::Int=0) = put(res, 1; priority=priority)
+request(res::Resource; priority::Real=0) = put(res, 1; priority=priority)
 
-function get(con::Container{N}, amount::N; priority::Int=0) where N<:Real
+function get(con::Container{N}, amount::N; priority::Real=0) where N<:Real
   get_ev = Get(con.env)
   con.get_queue[get_ev] = ContainerKey(priority, con.seid+=one(UInt), amount)
   @callback trigger_put(get_ev, con)
@@ -40,7 +40,7 @@ function get(con::Container{N}, amount::N; priority::Int=0) where N<:Real
   get_ev
 end
 
-release(res::Resource; priority::Int=0) = get(res, 1; priority=priority)
+release(res::Resource; priority::Real=0) = get(res, 1; priority=priority)
 
 function do_put(con::Container{N}, put_ev::Put, key::ContainerKey{N}) where N<:Real
   con.level + key.amount > con.capacity && return false

--- a/src/resources/stores.jl
+++ b/src/resources/stores.jl
@@ -1,12 +1,12 @@
 struct StorePutKey{T} <: ResourceKey
-  priority :: Int
+  priority :: Real
   id :: UInt
   item :: T
   StorePutKey{T}(priority, id, item) where T = new(priority, id, item)
 end
 
 struct StoreGetKey <: ResourceKey
-  priority :: Int
+  priority :: Real
   id :: UInt
   filter :: Function
 end
@@ -24,7 +24,7 @@ mutable struct Store{T} <: AbstractResource
   end
 end
 
-function put(sto::Store{T}, item::T; priority::Int=0) where T
+function put(sto::Store{T}, item::T; priority::Real=0) where T
   put_ev = Put(sto.env)
   sto.put_queue[put_ev] = StorePutKey{T}(priority, sto.seid+=one(UInt), item)
   @callback trigger_get(put_ev, sto)
@@ -34,7 +34,7 @@ end
 
 get_any_item(::T) where T = true
 
-function get(sto::Store{T}, filter::Function=get_any_item; priority::Int=0) where T
+function get(sto::Store{T}, filter::Function=get_any_item; priority::Real=0) where T
   get_ev = Get(sto.env)
   sto.get_queue[get_ev] = StoreGetKey(priority, sto.seid+=one(UInt), filter)
   @callback trigger_put(get_ev, sto)

--- a/src/resources/stores.jl
+++ b/src/resources/stores.jl
@@ -1,68 +1,68 @@
 struct StorePutKey{T} <: ResourceKey
-  priority :: Real
-  id :: UInt
-  item :: T
-  StorePutKey{T}(priority, id, item) where T = new(priority, id, item)
+    priority::Real
+    id::UInt
+    item::T
+    StorePutKey{T}(priority, id, item) where {T} = new(priority, id, item)
 end
 
 struct StoreGetKey <: ResourceKey
-  priority :: Real
-  id :: UInt
-  filter :: Function
+    priority::Real
+    id::UInt
+    filter::Function
 end
 
 mutable struct Store{T} <: AbstractResource
-  env :: Environment
-  capacity :: UInt
-  load :: UInt
-  items :: Dict{T, UInt}
-  seid :: UInt
-  put_queue :: DataStructures.PriorityQueue{Put, StorePutKey{T}}
-  get_queue :: DataStructures.PriorityQueue{Get, StoreGetKey}
-  function Store{T}(env::Environment; capacity::UInt=typemax(UInt)) where {T}
-    new(env, capacity, zero(UInt), Dict{T, UInt}(), zero(UInt), DataStructures.PriorityQueue{Put, StorePutKey{T}}(), DataStructures.PriorityQueue{Get, StoreGetKey}())
-  end
+    env::Environment
+    capacity::UInt
+    load::UInt
+    items::Dict{T,UInt}
+    seid::UInt
+    put_queue::DataStructures.PriorityQueue{Put,StorePutKey{T}}
+    get_queue::DataStructures.PriorityQueue{Get,StoreGetKey}
+    function Store{T}(env::Environment; capacity::UInt=typemax(UInt)) where {T}
+        new(env, capacity, zero(UInt), Dict{T,UInt}(), zero(UInt), DataStructures.PriorityQueue{Put,StorePutKey{T}}(), DataStructures.PriorityQueue{Get,StoreGetKey}())
+    end
 end
 
-function put(sto::Store{T}, item::T; priority::Real=0) where T
-  put_ev = Put(sto.env)
-  sto.put_queue[put_ev] = StorePutKey{T}(priority, sto.seid+=one(UInt), item)
-  @callback trigger_get(put_ev, sto)
-  trigger_put(put_ev, sto)
-  put_ev
+function put(sto::Store{T}, item::T; priority::Real=0) where {T}
+    put_ev = Put(sto.env)
+    sto.put_queue[put_ev] = StorePutKey{T}(priority, sto.seid += one(UInt), item)
+    @callback trigger_get(put_ev, sto)
+    trigger_put(put_ev, sto)
+    put_ev
 end
 
-get_any_item(::T) where T = true
+get_any_item(::T) where {T} = true
 
-function get(sto::Store{T}, filter::Function=get_any_item; priority::Real=0) where T
-  get_ev = Get(sto.env)
-  sto.get_queue[get_ev] = StoreGetKey(priority, sto.seid+=one(UInt), filter)
-  @callback trigger_put(get_ev, sto)
-  trigger_get(get_ev, sto)
-  get_ev
+function get(sto::Store{T}, filter::Function=get_any_item; priority::Real=0) where {T}
+    get_ev = Get(sto.env)
+    sto.get_queue[get_ev] = StoreGetKey(priority, sto.seid += one(UInt), filter)
+    @callback trigger_put(get_ev, sto)
+    trigger_get(get_ev, sto)
+    get_ev
 end
 
 function do_put(sto::Store{T}, put_ev::Put, key::StorePutKey{T}) where {T}
-  if sto.load < sto.capacity
-    sto.load += one(UInt)
-    sto.items[key.item] = get(sto.items, key.item, zero(UInt)) + one(UInt)
-    schedule(put_ev)
-  end
-  false
+    if sto.load < sto.capacity
+        sto.load += one(UInt)
+        sto.items[key.item] = get(sto.items, key.item, zero(UInt)) + one(UInt)
+        schedule(put_ev)
+    end
+    false
 end
 
 function do_get(sto::Store{T}, get_ev::Get, key::StoreGetKey) where {T}
-  for (item, number) in sto.items
-    if key.filter(item)
-      sto.load -= one(UInt)
-      if number === one(UInt)
-        delete!(sto.items, item)
-      else
-        sto.items[item] = number - one(UInt)
-      end
-      schedule(get_ev; value=item)
-      break
+    for (item, number) in sto.items
+        if key.filter(item)
+            sto.load -= one(UInt)
+            if number === one(UInt)
+                delete!(sto.items, item)
+            else
+                sto.items[item] = number - one(UInt)
+            end
+            schedule(get_ev; value=item)
+            break
+        end
     end
-  end
-  true
+    true
 end

--- a/src/simulations.jl
+++ b/src/simulations.jl
@@ -10,7 +10,7 @@ struct EmptySchedule <: Exception end
 
 struct EventKey
     time::Float64
-    priority::Int
+    priority::Real
     id::UInt
 end
 

--- a/src/simulations.jl
+++ b/src/simulations.jl
@@ -2,60 +2,60 @@ abstract type AbstractProcess <: AbstractEvent end
 abstract type DiscreteProcess <: AbstractProcess end
 
 struct InterruptException <: Exception
-  by :: AbstractProcess
-  cause :: Any
+    by::AbstractProcess
+    cause::Any
 end
 
 struct EmptySchedule <: Exception end
 
 struct EventKey
-  time :: Float64
-  priority :: Int
-  id :: UInt
+    time::Float64
+    priority::Int
+    id::UInt
 end
 
-function isless(a::EventKey, b::EventKey) :: Bool
-  (a.time < b.time) || (a.time === b.time && a.priority > b.priority) || (a.time === b.time && a.priority === b.priority && a.id < b.id)
+function isless(a::EventKey, b::EventKey)::Bool
+    (a.time < b.time) || (a.time === b.time && a.priority > b.priority) || (a.time === b.time && a.priority === b.priority && a.id < b.id)
 end
 
 mutable struct Simulation <: Environment
-  time :: Float64
-  heap :: DataStructures.PriorityQueue{BaseEvent, EventKey}
-  eid :: UInt
-  sid :: UInt
-  active_proc :: Union{AbstractProcess, Nothing}
-  function Simulation(initial_time::Number=zero(Float64))
-    new(initial_time, DataStructures.PriorityQueue{BaseEvent, EventKey}(), zero(UInt), zero(UInt), nothing)
-  end
+    time::Float64
+    heap::DataStructures.PriorityQueue{BaseEvent,EventKey}
+    eid::UInt
+    sid::UInt
+    active_proc::Union{AbstractProcess,Nothing}
+    function Simulation(initial_time::Number=zero(Float64))
+        new(initial_time, DataStructures.PriorityQueue{BaseEvent,EventKey}(), zero(UInt), zero(UInt), nothing)
+    end
 end
 
 function step(sim::Simulation)
-  isempty(sim.heap) && throw(EmptySchedule())
-  (bev, key) = DataStructures.peek(sim.heap)
-  DataStructures.dequeue!(sim.heap)
-  sim.time = key.time
-  bev.state = processed
-  for callback in bev.callbacks
-    callback()
-  end
+    isempty(sim.heap) && throw(EmptySchedule())
+    (bev, key) = DataStructures.peek(sim.heap)
+    DataStructures.dequeue!(sim.heap)
+    sim.time = key.time
+    bev.state = processed
+    for callback in bev.callbacks
+        callback()
+    end
 end
 
 function now(sim::Simulation)
-  sim.time
+    sim.time
 end
 
 function now(ev::AbstractEvent)
-  return now(environment(ev))
+    return now(environment(ev))
 end
 
-function active_process(sim::Simulation) :: AbstractProcess
-  sim.active_proc
+function active_process(sim::Simulation)::AbstractProcess
+    sim.active_proc
 end
 
 function reset_active_process(sim::Simulation)
-  sim.active_proc = nothing
+    sim.active_proc = nothing
 end
 
 function set_active_process(sim::Simulation, proc::AbstractProcess)
-  sim.active_proc = proc
+    sim.active_proc = proc
 end

--- a/src/utils/time.jl
+++ b/src/utils/time.jl
@@ -1,17 +1,17 @@
 function Simulation(initial_time::DateTime)
-  Simulation(Dates.datetime2epochms(initial_time))
+    Simulation(Dates.datetime2epochms(initial_time))
 end
 
 function run(env::Environment, until::DateTime)
-  run(env, Dates.datetime2epochms(until))
+    run(env, Dates.datetime2epochms(until))
 end
 
 function timeout(env::Environment, delay::Period; priority::Int=0, value::Any=nothing)
-  time = now(env)
-  del = Dates.datetime2epochms(Dates.epochms2datetime(time)+delay)-time
-  timeout(env, del; priority=priority, value=value)
+    time = now(env)
+    del = Dates.datetime2epochms(Dates.epochms2datetime(time) + delay) - time
+    timeout(env, del; priority=priority, value=value)
 end
 
 function nowDatetime(env::Environment)
-  Dates.epochms2datetime(now(env))
+    Dates.epochms2datetime(now(env))
 end

--- a/src/utils/time.jl
+++ b/src/utils/time.jl
@@ -6,7 +6,7 @@ function run(env::Environment, until::DateTime)
     run(env, Dates.datetime2epochms(until))
 end
 
-function timeout(env::Environment, delay::Period; priority::Int=0, value::Any=nothing)
+function timeout(env::Environment, delay::Period; priority::Real=0, value::Any=nothing)
     time = now(env)
     del = Dates.datetime2epochms(Dates.epochms2datetime(time) + delay) - time
     timeout(env, del; priority=priority, value=value)

--- a/test/resources/containers.jl
+++ b/test/resources/containers.jl
@@ -1,6 +1,6 @@
 using SimJulia
 
-@resumable function client(sim::Simulation, res::Resource, i::Int, priority::Int)
+@resumable function client(sim::Simulation, res::Resource, i::Int, priority::Real)
   println("$(now(sim)), client $i is waiting")
   @yield request(res, priority=priority)
   println("$(now(sim)), client $i is being served")


### PR DESCRIPTION
Extended the store and container objects so that priorities are not restricted to being integers.
This is a more general expression of priority which may make it easier at some point to use rank functions (https://github.com/BenLauwens/SimJulia.jl/issues/75).
This also avoids having to normalize (and sometimes scaling) priorities so that they are integer in queueing systems.