### PR TITLE
Restore the AirspeedVelocity benchmark suite

### DIFF
--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+ConcurrentSim = "6ed1e86c-fcaf-46a9-97e0-2b26a2cdb499"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+ResumableFunctions = "c5292f4c-5179-55e1-98c5-05642aab7184"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,8 @@
+using BenchmarkTools, Random
+
+include("processes_MM1.jl")
+include("processes_fibonnaci.jl")
+
+const SUITE = BenchmarkGroup()
+SUITE["MM1"] = @benchmarkable test_mm1(100.0) setup=(Random.seed!(1234)) evals=1
+SUITE["Fibonacci"] = @benchmarkable run_test()

--- a/benchmark/processes_MM1.jl
+++ b/benchmark/processes_MM1.jl
@@ -22,5 +22,7 @@ function test_mm1(n::Float64)
   run(sim, n)
 end
 
-test_mm1(100.0)
-@btime test_mm1(100.0)
+if abspath(PROGRAM_FILE) == @__FILE__
+  test_mm1(100.0)
+  @btime test_mm1(100.0)
+end

--- a/benchmark/processes_fibonnaci.jl
+++ b/benchmark/processes_fibonnaci.jl
@@ -15,5 +15,7 @@ function run_test()
   run(sim, 10)
 end
 
-run_test()
-@btime run_test()
+if abspath(PROGRAM_FILE) == @__FILE__
+  run_test()
+  @btime run_test()
+end


### PR DESCRIPTION
The Benchmarks workflow fails because AirspeedVelocity cannot find `benchmark/benchmarks.jl`. Add the required `SUITE` and benchmark environment, using the existing MM1 queue and Fibonacci process workloads. The standalone scripts still run directly; including them in the suite only loads their definitions. Reset the MM1 random seed for each sample so comparisons use the same simulated arrivals and service times.

Validation: both suite entries ran locally on Julia 1.13.0. AirspeedVelocity 0.6.0 also discovered the new suite and its project, then completed both workloads against master (`46af65d`) and this change (`820d1a9`), using the new suite for both revisions (`benchmark_on="820d1a9"`, `tune=false`, `nsamples_load_time=1`). An independent review found no issues.

The current PR's benchmark check will still use the missing suite from master: this workflow runs on `pull_request_target`, and the action defaults to `--bench-on=master`. The new suite repairs subsequent benchmark runs after merge.

No package API changes. Skip-Changelog applies; this account cannot add the label.
