### PR TITLE
Fix Julia CI and validate interrupt callers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
         version:
           - '1'
           - '1.10'
+          - '1.11'
+          - '1.12'
         os:
           - ubuntu-latest
         threads:
@@ -37,7 +39,7 @@ jobs:
             version: '1'
             threads: '1'
           - arch: x64
-            os: macos-latest
+            os: macos-15-intel
             version: '1'
             threads: '1'
           - arch: x64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # News
 
+## Unreleased
+
+- Report an `ArgumentError` before changing the event queue when `interrupt` is called on an unfinished process without an active process.
+
 ## v1.5.1 - 2025-08-15
 
 - Bump DataStructures to 0.19.

--- a/docs/src/guides/environments.md
+++ b/docs/src/guides/environments.md
@@ -72,7 +72,7 @@ Note
 !!! note
     Although the simulation time is technically unitless, you can pretend that it is, for example, in milliseconds and use it like a timestamp returned by `Base.Dates.datetime2epochm` to calculate a date or the day of the week. The `Simulation` constructor and the `run` function accept as argument a `Base.Dates.DateTime` and the `timeout` constructor a `Base.Dates.Delay`. Together with the convenience function `nowDateTime` a simulation can transparently schedule its events in seconds, minutes, hours, days, ...
 
-The function `active_process` is comparable to `Base.Libc.getpid` and returns the current active `Process`. If no process is active, a `NullException` is thrown. A process is active when its process function is being executed. It becomes inactive (or suspended) when it yields an event.
+The function `active_process` is comparable to `Base.Libc.getpid` and returns the current active `Process`. If no process is active, it returns `nothing`. A process is active when its process function is being executed. It becomes inactive (or suspended) when it yields an event.
 
 Thus, it only makes sense to call this function from within a process function or a function that is called by your process function:
 

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -175,7 +175,7 @@ DocTestSetup = nothing
 
 Imagine, you don’t want to wait until your electric vehicle is fully charged but want to interrupt the charging process and just start driving instead.
 
-ConcurrentSim allows you to interrupt a running process by calling the `interrupt` function:
+ConcurrentSim allows you to interrupt a running process by calling the `interrupt` function from an active process in the same simulation. Calling `interrupt` on an unfinished process when no process is active throws an `ArgumentError`:
 
 ```jldoctest
 julia> using ResumableFunctions

--- a/src/processes.jl
+++ b/src/processes.jl
@@ -57,8 +57,10 @@ end
 function interrupt(proc::Process, cause::Any=nothing)
   env = environment(proc)
   if proc.fsmi._state !== 0xff
+    by = active_process(env)
+    isnothing(by) && throw(ArgumentError("interrupt must be called from an active process"))
     proc.target isa Initialize && schedule(proc.target; priority=typemax(Int))
-    target = schedule(Interrupt(env); priority=typemax(Int), value=InterruptException(active_process(env), cause))
+    target = schedule(Interrupt(env); priority=typemax(Int), value=InterruptException(by, cause))
     @callback execute_interrupt(target, proc)
   end
   timeout(env; priority=typemax(Int))

--- a/test/test_jet.jl
+++ b/test/test_jet.jl
@@ -5,7 +5,7 @@ using Test
 using InteractiveUtils
 
 @testset "JET checks" begin
-    rep = report_package("ConcurrentSim";
+    rep = report_package(ConcurrentSim;
         ignored_modules=(
             AnyFrameModule(InteractiveUtils),
         )

--- a/test/test_processes.jl
+++ b/test/test_processes.jl
@@ -1,5 +1,6 @@
 using ConcurrentSim
 using ResumableFunctions
+using Test
 
 struct TestException <: Exception end
 
@@ -70,4 +71,40 @@ try
   run(sim)
 catch exc
   println("$exc has been thrown")
+end
+
+@resumable function record_interruption(sim::Simulation, trace)
+  try
+    @yield timeout(sim, 10)
+    push!(trace, now(sim))
+  catch exc
+    push!(trace, exc)
+  end
+end
+
+@resumable function interrupt_with_cause(sim::Simulation, proc::Process)
+  @yield timeout(sim, 2)
+  @yield interrupt(proc, :cancelled)
+end
+
+@testset "Interrupt caller and cause" begin
+  sim = Simulation()
+  trace = Any[]
+  proc = @process record_interruption(sim, trace)
+  @test_throws ArgumentError interrupt(proc)
+  run(sim, 1)
+  @test_throws ArgumentError interrupt(proc)
+  run(sim)
+  @test trace == [10.0]
+
+  sim = Simulation()
+  empty!(trace)
+  proc = @process record_interruption(sim, trace)
+  caller = @process interrupt_with_cause(sim, proc)
+  run(sim)
+  @test length(trace) == 1
+  exc = only(trace)
+  @test exc isa ConcurrentSim.InterruptException
+  @test exc.by === caller
+  @test exc.cause === :cancelled
 end


### PR DESCRIPTION
The Intel macOS job fails during Julia setup because `macos-latest` selects an ARM runner. The JET job fails because JET 0.12 requires a module argument; correcting that call exposes an invalid `InterruptException(nothing, cause)` constructor path when an unfinished process is interrupted without an active caller.

This change:
- selects `macos-15-intel` for x64 and adds Julia 1.11/1.12 to the existing 1.10/latest-stable Linux matrix with both thread counts;
- passes the loaded `ConcurrentSim` module to JET, preserving compatibility with older JET releases;
- rejects interrupts without an active caller using `ArgumentError` before changing the event queue. Tests cover rejection before initialization and while suspended, normal completion, and valid caller/cause delivery. Documentation and changelog describe the requirement.

Latest stable now covers Julia 1.13. Completed-process behavior is preserved.

Validation completed on Linux x86_64:
- Full standard package suite, including manual/docstring doctests and Aqua, passed on Julia 1.10.12, 1.11.9, 1.12.7, and 1.13.0 with both one and five threads. The existing resource-priority `@test_broken` remains.
- Fixed process regression tests and JET passed on all four versions with two threads: seven process assertions and zero JET reports. Resolved JET versions were 0.9.18, 0.9.20, and 0.12.1 as supported by Julia.
- Complete corrected package suite with JET enabled passed on Julia 1.13.0 with two threads.
- Exact downgrade workflow equivalent passed on master with Julia 1.10.12, DataStructures 0.19.0, ResumableFunctions 1.0.0, coverage, bounds checks, and `allow_reresolve=false`.
- Local website builds passed on Julia 1.12.7 and 1.13.0; website tooling requires Julia >=1.12. Package doctests passed on every supported minor.
- Independent review of all three commits, workflow YAML parsing, and `git diff --check` passed.

At head `fc3352f`, hosted checks also completed: [full Linux/macOS/Windows/docs CI](https://github.com/JuliaDynamics/ConcurrentSim.jl/actions/runs/34551261956), [JET/alpha](https://github.com/JuliaDynamics/ConcurrentSim.jl/actions/runs/34551261988), [downgrade](https://github.com/JuliaDynamics/ConcurrentSim.jl/actions/runs/34551262108), changelog, and spelling all passed. Intel macOS and Windows logs confirm Julia 1.13.0.

The sole remaining check failure is the pre-existing missing benchmark suite repaired in #166. Its target-triggered workflow reads the suite from master, so that check recovers once #166 is merged.
